### PR TITLE
Add Configuring Releases section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 **This project is still a WIP and should not be used on any production repositories**
 
+## Contents
+
+-   [What?](#what)
+-   [Why?](#why)
+-   [How?](#how)
+    -   [Tokens](#tokens)
+    -   [Inputs](#inputs)
+    -   [Repository Settings](#repository-settings)
+    -   [Configuring Releases](#configuring-releases)
+-   [Development](#development)
+    -   [Build](#build)
+    -   [Scripts](#scripts)
+
 ## What?
 
 This action can be used as part of automating the publish process of node libraries to npm. It handles the version update of the `package.json` and `package-lock.json` files for repositories with protected release branches.


### PR DESCRIPTION
## What does this change?

This PR adds a new section to the README which details the setup of semantic release using our recommended configuration. It also adds a contents section to the top of the file to make navigating the README easier.

## How can we measure success?

Users of this action also have recommendations on how to set up the release itself. 