### PR TITLE
Add additional changes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,17 @@ Workflows completed using the `secrets.GITHUB_TOKEN` will not trigger other work
 
 ### Inputs
 
-| Name            | Description                                                                             | Required | Default                              |
-| --------------- | --------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
-| github-token    | A GitHub token to complete the required actions                                         | true     | -                                    |
-| package-manager | The name of the package manager used: npm, yarn                                         | false    | npm                                  |
-| pr-author       | The author of version bump PRs                                                          | false    | guardian-ci                          |
-| pr-prefix       | The prefix to add to version bump PRs (note that a space will be added after the value) | false    | chore(release):                      |
-| release-branch  | The branch which releases are run from                                                  | false    | main                                 |
-| branch-prefix   | The prefix to add to the branch name to commit version bump changes to                  | false    | release-                             |
-| commit-user     | The username of the user to commit version bump changes with                            | false    | guardian-ci                          |
-| commit-email    | The email of the user to commit version bump changes with                               | false    | guardian-ci@users.noreply.github.com |
+| Name               | Description                                                                                                                                                                                   | Required | Default                              |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
+| github-token       | A GitHub token to complete the required actions                                                                                                                                               | true     | -                                    |
+| package-manager    | The name of the package manager used: npm, yarn                                                                                                                                               | false    | npm                                  |
+| additional-changes | A JSON object of additional changes where the key is a filename and the value is an array of acceptable changes in that file e.g. `{"README.md": ["- \"version\": \"", "+ \"version\": \""]}` | false    | {}                                   |
+| pr-author          | The author of version bump PRs                                                                                                                                                                | false    | guardian-ci                          |
+| pr-prefix          | The prefix to add to version bump PRs (note that a space will be added after the value)                                                                                                       | false    | chore(release):                      |
+| release-branch     | The branch which releases are run from                                                                                                                                                        | false    | main                                 |
+| branch-prefix      | The prefix to add to the branch name to commit version bump changes to                                                                                                                        | false    | release-                             |
+| commit-user        | The username of the user to commit version bump changes with                                                                                                                                  | false    | guardian-ci                          |
+| commit-email       | The email of the user to commit version bump changes with                                                                                                                                     | false    | guardian-ci@users.noreply.github.com |
 
 ### Repository Settings
 

--- a/README.md
+++ b/README.md
@@ -117,17 +117,29 @@ Workflows completed using the `secrets.GITHUB_TOKEN` will not trigger other work
 
 ### Inputs
 
-| Name               | Description                                                                                                                                                                                   | Required | Default                              |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
-| github-token       | A GitHub token to complete the required actions                                                                                                                                               | true     | -                                    |
-| package-manager    | The name of the package manager used: npm, yarn                                                                                                                                               | false    | npm                                  |
-| additional-changes | A JSON object of additional changes where the key is a filename and the value is an array of acceptable changes in that file e.g. `{"README.md": ["- \"version\": \"", "+ \"version\": \""]}` | false    | {}                                   |
-| pr-author          | The author of version bump PRs                                                                                                                                                                | false    | guardian-ci                          |
-| pr-prefix          | The prefix to add to version bump PRs (note that a space will be added after the value)                                                                                                       | false    | chore(release):                      |
-| release-branch     | The branch which releases are run from                                                                                                                                                        | false    | main                                 |
-| branch-prefix      | The prefix to add to the branch name to commit version bump changes to                                                                                                                        | false    | release-                             |
-| commit-user        | The username of the user to commit version bump changes with                                                                                                                                  | false    | guardian-ci                          |
-| commit-email       | The email of the user to commit version bump changes with                                                                                                                                     | false    | guardian-ci@users.noreply.github.com |
+| Name               | Description                                                                                                                                                                                                                                                        | Required | Default                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------ |
+| github-token       | A GitHub token to complete the required actions                                                                                                                                                                                                                    | true     | -                                    |
+| package-manager    | The name of the package manager used: npm, yarn                                                                                                                                                                                                                    | false    | npm                                  |
+| additional-changes | A JSON object of additional changes where the key is a filename and the value is an array of acceptable changes in that file e.g. `{"README.md": ["- \"version\": \"", "+ \"version\": \""]}` (see [validating changes](#validating-changes) for more information) | false    | {}                                   |
+| pr-author          | The author of version bump PRs                                                                                                                                                                                                                                     | false    | guardian-ci                          |
+| pr-prefix          | The prefix to add to version bump PRs (note that a space will be added after the value)                                                                                                                                                                            | false    | chore(release):                      |
+| release-branch     | The branch which releases are run from                                                                                                                                                                                                                             | false    | main                                 |
+| branch-prefix      | The prefix to add to the branch name to commit version bump changes to                                                                                                                                                                                             | false    | release-                             |
+| commit-user        | The username of the user to commit version bump changes with                                                                                                                                                                                                       | false    | guardian-ci                          |
+| commit-email       | The email of the user to commit version bump changes with                                                                                                                                                                                                          | false    | guardian-ci@users.noreply.github.com |
+
+### Validating Changes
+
+In order to be sure that the PR being approved automatically is limited in scope to the expected changes in a release, the action performs so checks against the PR diff. These checks simply verify that a number of pre-configured strings are present in the diff.
+
+For example, the diff for a version bump in the `package.json` might look something like this. By default, this action will verify that both `- \"version\": \"` and `+ \"version\": \"` appear in this diff.
+
+```
+"@@ -1,6 +1,6 @@\n {\n   \"name\": \"my-library\",\n-  \"version\": \"1.0.0\",\n+  \"version\": \"1.0.1\",\n   \"description\": \"This is a test library\",\n   \"main\": \"lib/index.js\","
+```
+
+The expected changes values provided through the `additional-changes` input are verified in the same way.
 
 ### Repository Settings
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'The name of the package manager used: npm, yarn'
     required: false
     default: npm
+  additional-changes:
+    description: 'A JSON object of additional changes where the key is a filename and the value is an array of acceptable changes in that file e.g. `{"README.md": ["-  \"version\": \"", "+  \"version\": \""]}`'
+    required: false
+    default: '{}'
   pr-author:
     description: The author of version bump PRs
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -7092,8 +7092,11 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
     }
     const allowedFiles = Object.keys(config.expectedChanges);
     const expectedFilesChanges = allowedFiles.length;
+    // Although this case would be caught implicity by the following checks
+    // checking it at this stage means that we can fail early and avoid
+    // calling the listFiles endpoint
     if (pullRequest.changed_files !== expectedFilesChanges) {
-        throw new Error(`Pull request changes ${pullRequest.changed_files} files. Expected ${expectedFilesChanges} changes - ${allowedFiles.join(', ')}`);
+        throw new Error(`Pull request changes ${pullRequest.changed_files} files. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
     }
     const { data: files } = yield octokit.pulls.listFiles(prData);
     for (const file of files) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7090,12 +7090,12 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
         core.info(`Pull request title does not start with "${config.pullRequestPrefix}", ignoring.`);
         return;
     }
-    const expectedFilesChanges = Object.keys(config.expectedChanges).length;
+    const allowedFiles = Object.keys(config.expectedChanges);
+    const expectedFilesChanges = allowedFiles.length;
     if (pullRequest.changed_files !== expectedFilesChanges) {
-        throw new Error(`Pull request changes ${pullRequest.changed_files} files. Expected ${expectedFilesChanges} changes.`);
+        throw new Error(`Pull request changes ${pullRequest.changed_files} files. Expected ${expectedFilesChanges} changes - ${allowedFiles.join(', ')}`);
     }
     const { data: files } = yield octokit.pulls.listFiles(prData);
-    const allowedFiles = Object.keys(config.expectedChanges);
     for (const file of files) {
         if (!allowedFiles.includes(file.filename)) {
             throw new Error(`Unallowed file (${file.filename}) changed. Allowed files are: ${allowedFiles.join(', ')}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6965,7 +6965,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConfig = void 0;
+exports.getConfig = exports.parseAdditionalChanges = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const versionBumpChange = ['-  "version": "', '+  "version": "'];
 const packageManagerConfig = {
@@ -6992,8 +6992,36 @@ const getFileChangesConfig = () => {
 };
 const getAdditionalChanges = () => {
     const additionalChanges = getConfigValue('additional-changes', '{}');
-    return JSON.parse(additionalChanges);
+    return exports.parseAdditionalChanges(additionalChanges);
 };
+const parseAdditionalChanges = (additionalChanges) => {
+    if (!additionalChanges || additionalChanges === '{}') {
+        return {};
+    }
+    let json;
+    try {
+        // eslint-disable-next-line prefer-const -- this is setting the value above so I don't know what eslint is complaining about
+        json = JSON.parse(additionalChanges);
+    }
+    catch (err) {
+        throw new Error('Invalid JSON provided for additional-changes input');
+    }
+    if (json !== Object(json) || Array.isArray(json)) {
+        throw new Error('additional-changes value must be an object');
+    }
+    for (const changes of Object.values(json)) {
+        if (!Array.isArray(changes)) {
+            throw new Error('values in additional-changes object must be arrays');
+        }
+        for (const change of changes) {
+            if (typeof change !== 'string') {
+                throw new Error('values in additional-changes object must be strings');
+            }
+        }
+    }
+    return json;
+};
+exports.parseAdditionalChanges = parseAdditionalChanges;
 const getConfig = () => {
     return Object.assign(Object.assign({}, getFileChangesConfig()), { pullRequestAuthor: getConfigValue('pr-author', 'guardian-ci'), pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'), releaseBranch: getConfigValue('release-branch', 'main'), newBranchPrefix: getConfigValue('branch-prefix', 'release-'), commitUser: getConfigValue('commit-user', 'guardian-ci'), commitEmail: getConfigValue('commit-email', 'guardian-ci@users.noreply.github.com') });
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -7092,9 +7092,11 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
     }
     const allowedFiles = Object.keys(config.expectedChanges);
     const expectedFilesChanges = allowedFiles.length;
-    // Although this case would be caught implicity by the following checks
+    // Although part of this case would be caught implicity by the following checks
     // checking it at this stage means that we can fail early and avoid
     // calling the listFiles endpoint
+    // This check does also catch the case when not as many changes as expected
+    // are made
     if (pullRequest.changed_files !== expectedFilesChanges) {
         throw new Error(`Pull request changes ${pullRequest.changed_files} ${pullRequest.changed_files === 1 ? 'file' : 'files'}. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -7040,6 +7040,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const exec_1 = __nccwpck_require__(1514);
 const github = __importStar(__nccwpck_require__(5438));
 const config_1 = __nccwpck_require__(6373);
+const utils_1 = __nccwpck_require__(1314);
 const decideAndTriggerAction = (config) => {
     var _a;
     const eventName = github.context.eventName;
@@ -7098,7 +7099,11 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
     // This check does also catch the case when not as many changes as expected
     // are made
     if (pullRequest.changed_files !== expectedFilesChanges) {
-        throw new Error(`Pull request changes ${pullRequest.changed_files} ${pullRequest.changed_files === 1 ? 'file' : 'files'}. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
+        throw new Error(`Pull request changes ${pullRequest.changed_files} ${utils_1.maybePluralise({
+            number: pullRequest.changed_files,
+            singular: 'file',
+            plural: 'files',
+        })}. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
     }
     const { data: files } = yield octokit.pulls.listFiles(prData);
     for (const file of files) {
@@ -7107,7 +7112,15 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
         }
         const expectedChanges = config.expectedChanges[file.filename];
         if (file.changes !== expectedChanges.length) {
-            throw new Error(`${file.changes} change(s) in file: ${file.filename}. Expected ${expectedChanges.length}`);
+            throw new Error(`${file.changes} ${utils_1.maybePluralise({
+                number: file.changes,
+                singular: 'change',
+                plural: 'changes',
+            })} in file: ${file.filename}. Expected ${expectedChanges.length} ${utils_1.maybePluralise({
+                number: expectedChanges.length,
+                singular: 'change',
+                plural: 'changes',
+            })}`);
         }
         if (file.patch) {
             for (const change of expectedChanges) {
@@ -7199,6 +7212,21 @@ function run() {
     });
 }
 void run();
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.maybePluralise = void 0;
+const maybePluralise = ({ number, singular, plural, }) => {
+    return number === 1 ? singular : plural;
+};
+exports.maybePluralise = maybePluralise;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -7096,7 +7096,7 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
     // checking it at this stage means that we can fail early and avoid
     // calling the listFiles endpoint
     if (pullRequest.changed_files !== expectedFilesChanges) {
-        throw new Error(`Pull request changes ${pullRequest.changed_files} files. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
+        throw new Error(`Pull request changes ${pullRequest.changed_files} ${pullRequest.changed_files === 1 ? 'file' : 'files'}. Expected to see changes to all of the following files: ${allowedFiles.join(', ')}`);
     }
     const { data: files } = yield octokit.pulls.listFiles(prData);
     for (const file of files) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7125,7 +7125,7 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
         if (file.patch) {
             for (const change of expectedChanges) {
                 if (!file.patch.includes(change)) {
-                    throw new Error(`Expected to see the following string in diff for ${file.filename}: ${change}`);
+                    throw new Error(`Expected to see the following string in diff for ${file.filename}: ${change}\n\nPR Diff: ${file.patch}`);
                 }
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,46 @@ const getFileChangesConfig = (): FileChangesConfig => {
 
 const getAdditionalChanges = (): FileChanges => {
 	const additionalChanges = getConfigValue('additional-changes', '{}');
-	return JSON.parse(additionalChanges) as FileChanges;
+
+	return parseAdditionalChanges(additionalChanges);
+};
+
+export const parseAdditionalChanges = (
+	additionalChanges: string,
+): FileChanges => {
+	if (!additionalChanges || additionalChanges === '{}') {
+		return {};
+	}
+
+	let json;
+	try {
+		// eslint-disable-next-line prefer-const -- this is setting the value above so I don't know what eslint is complaining about
+		json = JSON.parse(additionalChanges) as FileChanges;
+	} catch (err) {
+		throw new Error('Invalid JSON provided for additional-changes input');
+	}
+
+	if (json !== Object(json) || Array.isArray(json)) {
+		throw new Error('additional-changes value must be an object');
+	}
+
+	for (const changes of Object.values(json)) {
+		if (!Array.isArray(changes)) {
+			throw new Error(
+				'values in additional-changes object must be arrays',
+			);
+		}
+
+		for (const change of changes) {
+			if (typeof change !== 'string') {
+				throw new Error(
+					'values in additional-changes object must be strings',
+				);
+			}
+		}
+	}
+
+	return json;
 };
 
 export const getConfig = (): Config => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,11 @@ const checkApproveAndMergePR = async (
 	const allowedFiles = Object.keys(config.expectedChanges);
 	const expectedFilesChanges = allowedFiles.length;
 
-	// Although this case would be caught implicity by the following checks
+	// Although part of this case would be caught implicity by the following checks
 	// checking it at this stage means that we can fail early and avoid
 	// calling the listFiles endpoint
+	// This check does also catch the case when not as many changes as expected
+	// are made
 	if (pullRequest.changed_files !== expectedFilesChanges) {
 		throw new Error(
 			`Pull request changes ${pullRequest.changed_files} ${

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '@octokit/webhooks-definitions/schema';
 import type { Config } from './config';
 import { getConfig } from './config';
+import { maybePluralise } from './utils';
 
 interface Package {
 	version?: string;
@@ -95,9 +96,13 @@ const checkApproveAndMergePR = async (
 	// are made
 	if (pullRequest.changed_files !== expectedFilesChanges) {
 		throw new Error(
-			`Pull request changes ${pullRequest.changed_files} ${
-				pullRequest.changed_files === 1 ? 'file' : 'files'
-			}. Expected to see changes to all of the following files: ${allowedFiles.join(
+			`Pull request changes ${pullRequest.changed_files} ${maybePluralise(
+				{
+					number: pullRequest.changed_files,
+					singular: 'file',
+					plural: 'files',
+				},
+			)}. Expected to see changes to all of the following files: ${allowedFiles.join(
 				', ',
 			)}`,
 		);
@@ -118,7 +123,17 @@ const checkApproveAndMergePR = async (
 
 		if (file.changes !== expectedChanges.length) {
 			throw new Error(
-				`${file.changes} change(s) in file: ${file.filename}. Expected ${expectedChanges.length}`,
+				`${file.changes} ${maybePluralise({
+					number: file.changes,
+					singular: 'change',
+					plural: 'changes',
+				})} in file: ${file.filename}. Expected ${
+					expectedChanges.length
+				} ${maybePluralise({
+					number: expectedChanges.length,
+					singular: 'change',
+					plural: 'changes',
+				})}`,
 			);
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ const checkApproveAndMergePR = async (
 			for (const change of expectedChanges) {
 				if (!file.patch.includes(change)) {
 					throw new Error(
-						`Expected to see the following string in diff for ${file.filename}: ${change}`,
+						`Expected to see the following string in diff for ${file.filename}: ${change}\n\nPR Diff: ${file.patch}`,
 					);
 				}
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,9 @@ const checkApproveAndMergePR = async (
 	// calling the listFiles endpoint
 	if (pullRequest.changed_files !== expectedFilesChanges) {
 		throw new Error(
-			`Pull request changes ${
-				pullRequest.changed_files
-			} files. Expected to see changes to all of the following files: ${allowedFiles.join(
+			`Pull request changes ${pullRequest.changed_files} ${
+				pullRequest.changed_files === 1 ? 'file' : 'files'
+			}. Expected to see changes to all of the following files: ${allowedFiles.join(
 				', ',
 			)}`,
 		);

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,16 +85,20 @@ const checkApproveAndMergePR = async (
 		return;
 	}
 
-	const expectedFilesChanges = Object.keys(config.expectedChanges).length;
+	const allowedFiles = Object.keys(config.expectedChanges);
+	const expectedFilesChanges = allowedFiles.length;
 	if (pullRequest.changed_files !== expectedFilesChanges) {
 		throw new Error(
-			`Pull request changes ${pullRequest.changed_files} files. Expected ${expectedFilesChanges} changes.`,
+			`Pull request changes ${
+				pullRequest.changed_files
+			} files. Expected ${expectedFilesChanges} changes - ${allowedFiles.join(
+				', ',
+			)}`,
 		);
 	}
 
 	const { data: files } = await octokit.pulls.listFiles(prData);
 
-	const allowedFiles = Object.keys(config.expectedChanges);
 	for (const file of files) {
 		if (!allowedFiles.includes(file.filename)) {
 			throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,11 +87,15 @@ const checkApproveAndMergePR = async (
 
 	const allowedFiles = Object.keys(config.expectedChanges);
 	const expectedFilesChanges = allowedFiles.length;
+
+	// Although this case would be caught implicity by the following checks
+	// checking it at this stage means that we can fail early and avoid
+	// calling the listFiles endpoint
 	if (pullRequest.changed_files !== expectedFilesChanges) {
 		throw new Error(
 			`Pull request changes ${
 				pullRequest.changed_files
-			} files. Expected ${expectedFilesChanges} changes - ${allowedFiles.join(
+			} files. Expected to see changes to all of the following files: ${allowedFiles.join(
 				', ',
 			)}`,
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const maybePluralise = ({
+	number,
+	singular,
+	plural,
+}: {
+	number: number;
+	singular: string;
+	plural: string;
+}): string => {
+	return number === 1 ? singular : plural;
+};


### PR DESCRIPTION
## What does this change?

This PR adds a new `additional-changes` input to the action which can be used to provide any extra changes which should be expected in a version bump PR. In order to accommodate this, some refactoring has been carried out on the package manager configuration. Documentation of how changes are verified has been added to the README.

## How to test

On a repository that implements the action, open a PR that makes an extra change as well as the version bump changes. See that the action fails. Update the workflow configuration to permit the additional change an re-run the checks. See them pass.

## How can we measure success?

The action can be configured to expect additional changes, making it more flexible.