### PR TITLE
Use allowed merge method

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7054,6 +7054,17 @@ const decideAndTriggerAction = (config) => {
             throw new Error(`Unknown eventName: ${eventName}`);
     }
 };
+const decideMergeMethod = (repository) => {
+    if (repository.allow_squash_merge) {
+        return 'squash';
+    }
+    else if (repository.allow_rebase_merge) {
+        return 'rebase';
+    }
+    else {
+        return 'merge';
+    }
+};
 const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkApproveAndMergePR');
     core.debug(`Pull request: ${payload.pull_request.number}`);
@@ -7104,7 +7115,7 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
         return;
     }
     core.info(`PR mergeable. Merging`);
-    yield octokit.pulls.merge(prData);
+    yield octokit.pulls.merge(Object.assign(Object.assign({}, prData), { merge_method: decideMergeMethod(payload.repository) }));
 });
 const checkAndPRChanges = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkAndReleaseLibrary');

--- a/dist/index.js
+++ b/dist/index.js
@@ -7055,15 +7055,16 @@ const decideAndTriggerAction = (config) => {
     }
 };
 const decideMergeMethod = (repository) => {
+    if (repository.allow_merge_commit) {
+        return 'merge';
+    }
     if (repository.allow_squash_merge) {
         return 'squash';
     }
-    else if (repository.allow_rebase_merge) {
+    if (repository.allow_rebase_merge) {
         return 'rebase';
     }
-    else {
-        return 'merge';
-    }
+    return 'merge';
 };
 const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkApproveAndMergePR');

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,13 +32,19 @@ const decideAndTriggerAction = (config: Config) => {
 const decideMergeMethod = (
 	repository: Repository,
 ): 'merge' | 'squash' | 'rebase' => {
-	if (repository.allow_squash_merge) {
-		return 'squash';
-	} else if (repository.allow_rebase_merge) {
-		return 'rebase';
-	} else {
+	if (repository.allow_merge_commit) {
 		return 'merge';
 	}
+
+	if (repository.allow_squash_merge) {
+		return 'squash';
+	}
+
+	if (repository.allow_rebase_merge) {
+		return 'rebase';
+	}
+
+	return 'merge';
 };
 
 const checkApproveAndMergePR = async (


### PR DESCRIPTION
## What does this change?

This change adds a new function which determines the merge method to use based on those allowed by the repository. It will use the first method allowed in order of `merge`, `squash`, `rebase`. If no methods are allowed (which shouldn't ever be the case as GitHub doesn't allow it) then we return `merge` by default.

## How to test

Merge a PR which triggers a release to a repository that does not allow the `merge` method. See that it is merged using one of the alternative allowed methods.

## How can we measure success?

Version bump PRs are still merged on repositories that don't allow the `merge` method.
