### PR TITLE
use PR base object instead of repository object

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7116,7 +7116,7 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
         return;
     }
     core.info(`PR mergeable. Merging`);
-    yield octokit.pulls.merge(Object.assign(Object.assign({}, prData), { merge_method: decideMergeMethod(payload.repository) }));
+    yield octokit.pulls.merge(Object.assign(Object.assign({}, prData), { merge_method: decideMergeMethod(payload.pull_request.base.repo) }));
 });
 const checkAndPRChanges = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkAndReleaseLibrary');

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ const checkApproveAndMergePR = async (
 
 	await octokit.pulls.merge({
 		...prData,
-		merge_method: decideMergeMethod(payload.repository),
+		merge_method: decideMergeMethod(payload.pull_request.base.repo),
 	});
 };
 


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/actions-merge-release-changes-to-protected-branch/pull/24, we added a new function which determines the merge method to use based on those allowed by the repository. This used the `payload.repository.allow_*_commit` values to determine which method to use. Unfortunately this option is only available on some repository objects. This PR updates the logic to use the `payload.pull_request.base.repo.allow_*_commit` values which do exist. Base is used over head to cater for PRs from forks.

Reference: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request

## How to test

Merge a PR which triggers a release to a repository that does not allow the merge method. See that it is merged using one of the alternative allowed methods.

## How can we measure success?

Version bump PRs are still merged on repositories that don't allow the merge method.