### PR TITLE
fix: only add expected file changes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7154,8 +7154,9 @@ const checkAndPRChanges = (payload, config) => __awaiter(void 0, void 0, void 0,
     yield exec_1.exec(`git config --global user.name "${config.commitUser}"`);
     yield exec_1.exec(`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`);
     yield exec_1.exec(`git checkout -b "${newBranch}"`);
-    yield exec_1.exec(`git add package.json`);
-    yield exec_1.exec(`git add package-lock.json`);
+    for (const file of config.allowedFiles) {
+        yield exec_1.exec(`git add ${file}`);
+    }
     yield exec_1.exec(`git commit -m "${message}"`);
     yield exec_1.exec(`git status`);
     yield exec_1.exec(`git push -u origin "${newBranch}"`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,11 @@ const checkAndPRChanges = async (payload: PushEvent, config: Config) => {
 	);
 
 	await exec(`git checkout -b "${newBranch}"`);
-	await exec(`git add package.json`);
-	await exec(`git add package-lock.json`);
+
+	for (const file of config.allowedFiles) {
+		await exec(`git add ${file}`);
+	}
+
 	await exec(`git commit -m "${message}"`);
 	await exec(`git status`);
 	await exec(`git push -u origin "${newBranch}"`);


### PR DESCRIPTION
## What does this change?

This PR updates the logic used to add any changes to cater for the fact that different files change depending on the package manager used by the target repository. Instead of hardcoding the addition of the `package.json` and `package-lock.json`, we look through the `config.allowedFiles` array and add those files.

## How to test

Try out the action on a repository that uses `yarn` and see that it still works as expected.

## How can we measure success?

This action works for repositories using both `yarn` and `npm`