### PR TITLE
Fix yarn config

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6976,7 +6976,7 @@ const packageManagerConfig = {
     },
     yarn: {
         maxFilesChanged: 1,
-        maxFileChanges: 1,
+        maxFileChanges: 2,
         allowedFiles: ['package.json'],
         expectedChanges: ['-  "version": "', '+  "version": "'],
     },
@@ -7098,7 +7098,7 @@ const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, vo
             throw new Error(`Unallowed file (${file.filename}) changed. Allowed files are: ${config.allowedFiles.join(', ')}`);
         }
         if (file.changes > config.maxFileChanges) {
-            throw new Error(`More than ${config.maxFileChanges} in file: ${file.filename}`);
+            throw new Error(`More than ${config.maxFileChanges} change(s) in file: ${file.filename}`);
         }
         if (file.patch) {
             for (const change of config.expectedChanges) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ const packageManagerConfig: Record<string, PackageManagerConfig> = {
 	},
 	yarn: {
 		maxFilesChanged: 1,
-		maxFileChanges: 1,
+		maxFileChanges: 2,
 		allowedFiles: ['package.json'],
 		expectedChanges: ['-  "version": "', '+  "version": "'],
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ const checkApproveAndMergePR = async (
 
 		if (file.changes > config.maxFileChanges) {
 			throw new Error(
-				`More than ${config.maxFileChanges} in file: ${file.filename}`,
+				`More than ${config.maxFileChanges} change(s) in file: ${file.filename}`,
 			);
 		}
 


### PR DESCRIPTION
## What does this change?

This PR updates the package manager specific configuration for `yarn` and fixes an incorrect error message.

## How to test

Run a release on a repository that uses `yarn` as its package manager and see that the process completes as expected.

## How can we measure success?

Releases run for repositories that use `yarn` too.