### PR TITLE
Add a paragraph detailing the assumptions made when merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ There are two steps in the process, both handled by this action:
 1. If a merge to main results in a new publish, commit the changes to `package.json` and `package-lock.json` and open a new PR for them
 2. If a new PR is opened, check if it a version bump PR and, if it is, approve it and merge it
 
+Note that the merge step assumes that the status checks have already passed, that the configured approver meets any codeowner requirements and that there are no other requirements before merging. The action will attempt to merge the PR immediately after approving it so any unmet conditions will cause the process to fail. If there are any other requirements, these can be addressed in a job in the CI workflow which is added to the `needs` value of the approve and merge job. See the `Approve and merge PR` section for [an example of the `needs` value](#approve-and-merge-pr).
+
 In order to run these steps, two workflow files are required in your project.
 
 #### **Open PR**


### PR DESCRIPTION
## What does this change?

This PR adds a section to the README detailing the assumptions made about the merge-ability of a PR following automatic approval. 

## How can we measure success?

Users are clear on the behaviour of the action