### PR TITLE
Remove WIP warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # @guardian/actions-merge-release-changes-to-protected-branch
 
-**This project is still a WIP and should not be used on any production repositories**
-
 ## Contents
 
 -   [What?](#what)


### PR DESCRIPTION
## What does this change?

This PR removes the warning from the top of the README that states this project is a WIP ahead of an impending v1 release.