### PR TITLE
Use fs to get new version number

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7019,6 +7019,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.raisePullRequest = void 0;
+const fs_1 = __nccwpck_require__(5747);
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const github_1 = __nccwpck_require__(3933);
@@ -7041,20 +7042,7 @@ const raisePullRequest = ({ payload, config, }) => __awaiter(void 0, void 0, voi
     /*************************************/
     core_1.info('Changes detected. Creating pull request');
     /*************************************/
-    core_1.startGroup('Getting new package version');
-    let output = '';
-    yield exec_1.exec('cat package.json', [], {
-        listeners: {
-            stdout: (data) => {
-                output += data.toString();
-            },
-        },
-    });
-    const { version: newVersion } = JSON.parse(output);
-    if (!newVersion) {
-        throw new Error('Could not find version number');
-    }
-    core_1.endGroup();
+    const newVersion = getNewVersionFromPackageJson();
     /*************************************/
     core_1.startGroup('Committing changes');
     const message = `${config.pullRequestPrefix} ${newVersion}`;
@@ -7083,6 +7071,26 @@ const raisePullRequest = ({ payload, config, }) => __awaiter(void 0, void 0, voi
     });
 });
 exports.raisePullRequest = raisePullRequest;
+const getNewVersionFromPackageJson = () => {
+    core_1.startGroup('Getting new package version');
+    try {
+        const data = fs_1.readFileSync('./package.json', 'utf8');
+        const { version } = JSON.parse(data);
+        if (!version) {
+            throw new Error('Could not find version number in package.json');
+        }
+        return version;
+    }
+    catch (e) {
+        if (e instanceof Error) {
+            core_1.debug(e.message);
+        }
+        throw new Error('Error getting the new version number. See debug logs for more information.');
+    }
+    finally {
+        core_1.endGroup();
+    }
+};
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -7079,6 +7079,7 @@ const getNewVersionFromPackageJson = () => {
         if (!version) {
             throw new Error('Could not find version number in package.json');
         }
+        core_1.info(`New version is: ${version}`);
         return version;
     }
     catch (e) {

--- a/src/actions/raise-pull-request.ts
+++ b/src/actions/raise-pull-request.ts
@@ -97,6 +97,8 @@ const getNewVersionFromPackageJson = (): string => {
 			throw new Error('Could not find version number in package.json');
 		}
 
+		info(`New version is: ${version}`);
+
 		return version;
 	} catch (e) {
 		if (e instanceof Error) {

--- a/src/actions/raise-pull-request.ts
+++ b/src/actions/raise-pull-request.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { debug, endGroup, info, startGroup } from '@actions/core';
 import { exec } from '@actions/exec';
 import type { PushEvent } from '@octokit/webhooks-definitions/schema';
@@ -44,24 +45,7 @@ export const raisePullRequest = async ({
 
 	/*************************************/
 
-	startGroup('Getting new package version');
-
-	let output = '';
-	await exec('cat package.json', [], {
-		listeners: {
-			stdout: (data: Buffer) => {
-				output += data.toString();
-			},
-		},
-	});
-
-	const { version: newVersion } = JSON.parse(output) as PackageJson;
-
-	if (!newVersion) {
-		throw new Error('Could not find version number');
-	}
-
-	endGroup();
+	const newVersion = getNewVersionFromPackageJson();
 
 	/*************************************/
 
@@ -101,4 +85,27 @@ export const raisePullRequest = async ({
 		base: config.releaseBranch,
 		head: newBranch,
 	});
+};
+
+const getNewVersionFromPackageJson = (): string => {
+	startGroup('Getting new package version');
+	try {
+		const data = readFileSync('./package.json', 'utf8');
+		const { version } = JSON.parse(data) as PackageJson;
+
+		if (!version) {
+			throw new Error('Could not find version number in package.json');
+		}
+
+		return version;
+	} catch (e) {
+		if (e instanceof Error) {
+			debug(e.message);
+		}
+		throw new Error(
+			'Error getting the new version number. See debug logs for more information.',
+		);
+	} finally {
+		endGroup();
+	}
 };


### PR DESCRIPTION
## What does this change?

Currently, we get the new version number by `cat`ing the `package.json` and then parsing the output. This results in the `package.json` being written to the logs which adds clutter. This PR uses `fs` to read the file instead.

## How to test

Merge a commit to the main branch in a repo that uses this action and see it in action.

## How can we measure success?

Less cluttered logs