### PR TITLE
chore(deps): dependabot 06/04/21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1047,9 +1047,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.21",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.21.tgz",
-      "integrity": "sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==",
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,15 +1181,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.18.0.tgz",
-      "integrity": "sha512-92h723Kblt9JcT2RRY3QS2xefFKar4ZQFVs3GityOKWQYgtajxt/tuXIzL7sVCUlM1hgreiV5gkGYyBpdOwO6A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.20.0.tgz",
+      "integrity": "sha512-sQNlf6rjLq2yB5lELl3gOE7OuoA/6IVXJUJ+Vs7emrQMva14CkOwyQwD7CW+TkmOJ4Q/YGmoDLmbfFrpGmbKng==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.18.0",
-        "@typescript-eslint/types": "4.18.0",
-        "@typescript-eslint/typescript-estree": "4.18.0",
+        "@typescript-eslint/scope-manager": "4.20.0",
+        "@typescript-eslint/types": "4.20.0",
+        "@typescript-eslint/typescript-estree": "4.20.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
@@ -1250,29 +1250,29 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz",
-      "integrity": "sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz",
+      "integrity": "sha512-/zm6WR6iclD5HhGpcwl/GOYDTzrTHmvf8LLLkwKqqPKG6+KZt/CfSgPCiybshmck66M2L5fWSF/MKNuCwtKQSQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.18.0",
-        "@typescript-eslint/visitor-keys": "4.18.0"
+        "@typescript-eslint/types": "4.20.0",
+        "@typescript-eslint/visitor-keys": "4.20.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.18.0.tgz",
-      "integrity": "sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.20.0.tgz",
+      "integrity": "sha512-cYY+1PIjei1nk49JAPnH1VEnu7OYdWRdJhYI5wiKOUMhLTG1qsx5cQxCUTuwWCmQoyriadz3Ni8HZmGSofeC+w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz",
-      "integrity": "sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz",
+      "integrity": "sha512-Knpp0reOd4ZsyoEJdW8i/sK3mtZ47Ls7ZHvD8WVABNx5Xnn7KhenMTRGegoyMTx6TiXlOVgMz9r0pDgXTEEIHA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.18.0",
-        "@typescript-eslint/visitor-keys": "4.18.0",
+        "@typescript-eslint/types": "4.20.0",
+        "@typescript-eslint/visitor-keys": "4.20.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1281,12 +1281,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz",
-      "integrity": "sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz",
+      "integrity": "sha512-NXKRM3oOVQL8yNFDNCZuieRIwZ5UtjNLYtmMx2PacEAGmbaEYtGgVHUHVyZvU/0rYZcizdrWjDo+WBtRPSgq+A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/types": "4.20.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -2515,9 +2515,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.2.tgz",
-      "integrity": "sha512-cicWDr+RvTAOKS3Q/k03+Z3odt3VCiWamNUHWd6QWbVQWcYJyYgUTu8x0mx9GfeDEimawU5kQC+nQ3MFxIM6bw==",
+      "version": "24.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.4.tgz",
+      "integrity": "sha512-3n5oY1+fictanuFkTWPwSlehugBTAgwLnYLFsCllzE3Pl1BwywHl5fL0HFxmMjoQY8xhUDk8uAWc3S4JOHGh3A==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,41 +1195,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.19.0.tgz",
-      "integrity": "sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.20.0.tgz",
+      "integrity": "sha512-m6vDtgL9EABdjMtKVw5rr6DdeMCH3OA1vFb0dAyuZSa3e5yw1YRzlwFnm9knma9Lz6b2GPvoNSa8vOXrqsaglA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.19.0",
-        "@typescript-eslint/types": "4.19.0",
-        "@typescript-eslint/typescript-estree": "4.19.0",
+        "@typescript-eslint/scope-manager": "4.20.0",
+        "@typescript-eslint/types": "4.20.0",
+        "@typescript-eslint/typescript-estree": "4.20.0",
         "debug": "^4.1.1"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz",
-          "integrity": "sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz",
+          "integrity": "sha512-/zm6WR6iclD5HhGpcwl/GOYDTzrTHmvf8LLLkwKqqPKG6+KZt/CfSgPCiybshmck66M2L5fWSF/MKNuCwtKQSQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
-            "@typescript-eslint/visitor-keys": "4.19.0"
+            "@typescript-eslint/types": "4.20.0",
+            "@typescript-eslint/visitor-keys": "4.20.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.19.0.tgz",
-          "integrity": "sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.20.0.tgz",
+          "integrity": "sha512-cYY+1PIjei1nk49JAPnH1VEnu7OYdWRdJhYI5wiKOUMhLTG1qsx5cQxCUTuwWCmQoyriadz3Ni8HZmGSofeC+w==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz",
-          "integrity": "sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz",
+          "integrity": "sha512-Knpp0reOd4ZsyoEJdW8i/sK3mtZ47Ls7ZHvD8WVABNx5Xnn7KhenMTRGegoyMTx6TiXlOVgMz9r0pDgXTEEIHA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
-            "@typescript-eslint/visitor-keys": "4.19.0",
+            "@typescript-eslint/types": "4.20.0",
+            "@typescript-eslint/visitor-keys": "4.20.0",
             "debug": "^4.1.1",
             "globby": "^11.0.1",
             "is-glob": "^4.0.1",
@@ -1238,12 +1238,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz",
-          "integrity": "sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz",
+          "integrity": "sha512-NXKRM3oOVQL8yNFDNCZuieRIwZ5UtjNLYtmMx2PacEAGmbaEYtGgVHUHVyZvU/0rYZcizdrWjDo+WBtRPSgq+A==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
+            "@typescript-eslint/types": "4.20.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,13 +1108,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz",
-      "integrity": "sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.20.0.tgz",
+      "integrity": "sha512-sw+3HO5aehYqn5w177z2D82ZQlqHCwcKSMboueo7oE4KU9QiC0SAgfS/D4z9xXvpTc8Bt41Raa9fBR8T2tIhoQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.19.0",
-        "@typescript-eslint/scope-manager": "4.19.0",
+        "@typescript-eslint/experimental-utils": "4.20.0",
+        "@typescript-eslint/scope-manager": "4.20.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -1124,43 +1124,43 @@
       },
       "dependencies": {
         "@typescript-eslint/experimental-utils": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz",
-          "integrity": "sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.20.0.tgz",
+          "integrity": "sha512-sQNlf6rjLq2yB5lELl3gOE7OuoA/6IVXJUJ+Vs7emrQMva14CkOwyQwD7CW+TkmOJ4Q/YGmoDLmbfFrpGmbKng==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/scope-manager": "4.19.0",
-            "@typescript-eslint/types": "4.19.0",
-            "@typescript-eslint/typescript-estree": "4.19.0",
+            "@typescript-eslint/scope-manager": "4.20.0",
+            "@typescript-eslint/types": "4.20.0",
+            "@typescript-eslint/typescript-estree": "4.20.0",
             "eslint-scope": "^5.0.0",
             "eslint-utils": "^2.0.0"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz",
-          "integrity": "sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz",
+          "integrity": "sha512-/zm6WR6iclD5HhGpcwl/GOYDTzrTHmvf8LLLkwKqqPKG6+KZt/CfSgPCiybshmck66M2L5fWSF/MKNuCwtKQSQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
-            "@typescript-eslint/visitor-keys": "4.19.0"
+            "@typescript-eslint/types": "4.20.0",
+            "@typescript-eslint/visitor-keys": "4.20.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.19.0.tgz",
-          "integrity": "sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.20.0.tgz",
+          "integrity": "sha512-cYY+1PIjei1nk49JAPnH1VEnu7OYdWRdJhYI5wiKOUMhLTG1qsx5cQxCUTuwWCmQoyriadz3Ni8HZmGSofeC+w==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz",
-          "integrity": "sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz",
+          "integrity": "sha512-Knpp0reOd4ZsyoEJdW8i/sK3mtZ47Ls7ZHvD8WVABNx5Xnn7KhenMTRGegoyMTx6TiXlOVgMz9r0pDgXTEEIHA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
-            "@typescript-eslint/visitor-keys": "4.19.0",
+            "@typescript-eslint/types": "4.20.0",
+            "@typescript-eslint/visitor-keys": "4.20.0",
             "debug": "^4.1.1",
             "globby": "^11.0.1",
             "is-glob": "^4.0.1",
@@ -1169,12 +1169,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz",
-          "integrity": "sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==",
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz",
+          "integrity": "sha512-NXKRM3oOVQL8yNFDNCZuieRIwZ5UtjNLYtmMx2PacEAGmbaEYtGgVHUHVyZvU/0rYZcizdrWjDo+WBtRPSgq+A==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.19.0",
+            "@typescript-eslint/types": "4.20.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.3.2",
+    "eslint-plugin-jest": "^24.3.4",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "husky": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.22",
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
-    "@typescript-eslint/parser": "^4.19.0",
+		"@typescript-eslint/parser": "^4.20.0",
     "@vercel/ncc": "^0.27.0",
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/webhooks-definitions": "^3.62.5",
     "@types/jest": "^26.0.22",
     "@types/node": "^14.14.37",
-    "@typescript-eslint/eslint-plugin": "^4.19.0",
+    "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.19.0",
     "@vercel/ncc": "^0.27.0",
     "eslint": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@guardian/prettier": "^0.5.0",
     "@octokit/types": "^6.13.0",
     "@octokit/webhooks-definitions": "^3.62.5",
-    "@types/jest": "^26.0.21",
+    "@types/jest": "^26.0.22",
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",


### PR DESCRIPTION
* Bumps [@types/jest](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/jest) from 26.0.21 to 26.0.22.
* Bumps [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) from 4.19.0 to 4.20.0.
* Bumps [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser) from 4.19.0 to 4.20.0.
* Bumps [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) from 24.3.2 to 24.3.4.