### PR TITLE
chore: deps (28/06)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -525,19 +525,154 @@
       }
     },
     "@guardian/eslint-config-typescript": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.5.0.tgz",
-      "integrity": "sha512-bCLWYgjNUNzppF+kD2IWmWnvvPSZRMHnNU1Yku9nHqlDOgE8HdEkdfrMc6fWuD/I/HyWW9p5UJweeGfgRSypVw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.6.0.tgz",
+      "integrity": "sha512-kgMNiBaZkHC9X2EbhIOn+//uFSDCWxjouK6vlC0IIb3qqlZseiIqxEav+Llm8w5fPinHh7v33aJfK+Z4vHGdCQ==",
       "dev": true,
       "requires": {
-        "@guardian/eslint-config": "^0.5.0"
+        "@guardian/eslint-config": "^0.6.0",
+        "@typescript-eslint/eslint-plugin": "4.26.0",
+        "@typescript-eslint/parser": "4.26.0"
       },
       "dependencies": {
         "@guardian/eslint-config": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.5.0.tgz",
-          "integrity": "sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.6.0.tgz",
+          "integrity": "sha512-ZGU26EvYl09Py2xDlA/F+QACFBr8nff3gSTtAWrRTbxppa1ImEgxzkZM8xWuiYRNhowG0r/Kf8wSDPMzCdN5Tg==",
+          "dev": true,
+          "requires": {
+            "eslint-config-prettier": "8.3.0",
+            "eslint-plugin-eslint-comments": "3.2.0",
+            "eslint-plugin-import": "2.23.4",
+            "eslint-plugin-prettier": "3.4.0"
+          }
+        },
+        "@typescript-eslint/eslint-plugin": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz",
+          "integrity": "sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/experimental-utils": "4.26.0",
+            "@typescript-eslint/scope-manager": "4.26.0",
+            "debug": "^4.3.1",
+            "functional-red-black-tree": "^1.0.1",
+            "lodash": "^4.17.21",
+            "regexpp": "^3.1.0",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/experimental-utils": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.0.tgz",
+          "integrity": "sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.7",
+            "@typescript-eslint/scope-manager": "4.26.0",
+            "@typescript-eslint/types": "4.26.0",
+            "@typescript-eslint/typescript-estree": "4.26.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.0.tgz",
+          "integrity": "sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "4.26.0",
+            "@typescript-eslint/types": "4.26.0",
+            "@typescript-eslint/typescript-estree": "4.26.0",
+            "debug": "^4.3.1"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz",
+          "integrity": "sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.26.0",
+            "@typescript-eslint/visitor-keys": "4.26.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.0.tgz",
+          "integrity": "sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==",
           "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.0.tgz",
+          "integrity": "sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.26.0",
+            "@typescript-eslint/visitor-keys": "4.26.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.0.tgz",
+          "integrity": "sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.26.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1236,41 +1236,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.1.tgz",
-      "integrity": "sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.0.tgz",
+      "integrity": "sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.26.1",
-        "@typescript-eslint/types": "4.26.1",
-        "@typescript-eslint/typescript-estree": "4.26.1",
+        "@typescript-eslint/scope-manager": "4.28.0",
+        "@typescript-eslint/types": "4.28.0",
+        "@typescript-eslint/typescript-estree": "4.28.0",
         "debug": "^4.3.1"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "4.26.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz",
-          "integrity": "sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
+          "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.26.1",
-            "@typescript-eslint/visitor-keys": "4.26.1"
+            "@typescript-eslint/types": "4.28.0",
+            "@typescript-eslint/visitor-keys": "4.28.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.26.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.1.tgz",
-          "integrity": "sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
+          "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.26.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz",
-          "integrity": "sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
+          "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.26.1",
-            "@typescript-eslint/visitor-keys": "4.26.1",
+            "@typescript-eslint/types": "4.28.0",
+            "@typescript-eslint/visitor-keys": "4.28.0",
             "debug": "^4.3.1",
             "globby": "^11.0.3",
             "is-glob": "^4.0.1",
@@ -1279,19 +1279,19 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.26.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz",
-          "integrity": "sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
+          "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.26.1",
+            "@typescript-eslint/types": "4.28.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         },
         "globby": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,59 +1111,58 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.27.0.tgz",
-      "integrity": "sha512-DsLqxeUfLVNp3AO7PC3JyaddmEHTtI9qTSAs+RB6ja27QvIM0TA8Cizn1qcS6vOu+WDLFJzkwkgweiyFhssDdQ==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz",
+      "integrity": "sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.27.0",
-        "@typescript-eslint/scope-manager": "4.27.0",
+        "@typescript-eslint/experimental-utils": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
-        "lodash": "^4.17.21",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
         "@typescript-eslint/experimental-utils": {
-          "version": "4.27.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.27.0.tgz",
-          "integrity": "sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz",
+          "integrity": "sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.7",
-            "@typescript-eslint/scope-manager": "4.27.0",
-            "@typescript-eslint/types": "4.27.0",
-            "@typescript-eslint/typescript-estree": "4.27.0",
+            "@typescript-eslint/scope-manager": "4.28.0",
+            "@typescript-eslint/types": "4.28.0",
+            "@typescript-eslint/typescript-estree": "4.28.0",
             "eslint-scope": "^5.1.1",
             "eslint-utils": "^3.0.0"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "4.27.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz",
-          "integrity": "sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
+          "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.27.0",
-            "@typescript-eslint/visitor-keys": "4.27.0"
+            "@typescript-eslint/types": "4.28.0",
+            "@typescript-eslint/visitor-keys": "4.28.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.27.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.27.0.tgz",
-          "integrity": "sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
+          "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.27.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.27.0.tgz",
-          "integrity": "sha512-KH03GUsUj41sRLLEy2JHstnezgpS5VNhrJouRdmh6yNdQ+yl8w5LrSwBkExM+jWwCJa7Ct2c8yl8NdtNRyQO6g==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
+          "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.27.0",
-            "@typescript-eslint/visitor-keys": "4.27.0",
+            "@typescript-eslint/types": "4.28.0",
+            "@typescript-eslint/visitor-keys": "4.28.0",
             "debug": "^4.3.1",
             "globby": "^11.0.3",
             "is-glob": "^4.0.1",
@@ -1172,12 +1171,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.27.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.27.0.tgz",
-          "integrity": "sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==",
+          "version": "4.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
+          "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.27.0",
+            "@typescript-eslint/types": "4.28.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         },
@@ -1208,12 +1207,6 @@
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,10 +513,16 @@
       }
     },
     "@guardian/eslint-config": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.5.0.tgz",
-      "integrity": "sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.6.0.tgz",
+      "integrity": "sha512-ZGU26EvYl09Py2xDlA/F+QACFBr8nff3gSTtAWrRTbxppa1ImEgxzkZM8xWuiYRNhowG0r/Kf8wSDPMzCdN5Tg==",
+      "dev": true,
+      "requires": {
+        "eslint-config-prettier": "8.3.0",
+        "eslint-plugin-eslint-comments": "3.2.0",
+        "eslint-plugin-import": "2.23.4",
+        "eslint-plugin-prettier": "3.4.0"
+      }
     },
     "@guardian/eslint-config-typescript": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@actions/github": "^5.0.0"
   },
   "devDependencies": {
-    "@guardian/eslint-config": "^0.5.0",
+    "@guardian/eslint-config": "^0.6.0",
     "@guardian/eslint-config-typescript": "^0.5.0",
     "@guardian/prettier": "^0.6.0",
     "@octokit/types": "^6.16.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.23",
     "@types/node": "^15.12.4",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
-    "@typescript-eslint/parser": "^4.26.1",
+    "@typescript-eslint/parser": "^4.28.0",
     "@vercel/ncc": "^0.28.5",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@guardian/eslint-config": "^0.6.0",
-    "@guardian/eslint-config-typescript": "^0.5.0",
+		"@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
     "@octokit/types": "^6.16.4",
     "@octokit/webhooks-definitions": "^3.67.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/webhooks-definitions": "^3.67.3",
     "@types/jest": "^26.0.23",
     "@types/node": "^15.12.4",
-    "@typescript-eslint/eslint-plugin": "^4.27.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.0",
     "@typescript-eslint/parser": "^4.28.0",
     "@vercel/ncc": "^0.28.5",
     "eslint": "^7.29.0",


### PR DESCRIPTION
* bump @typescript-eslint/parser from 4.26.1 to 4.28.0
* bump @guardian/eslint-config from 0.5.0 to 0.6.0
* bump @typescript-eslint/eslint-plugin from 4.27.0 to 4.28.0
* bump @guardian/eslint-config-typescript from 0.5.0 to 0.6.0