### PR TITLE
Add engines config to prevent yarn use

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "ts-jest": "^26.5.6",
     "type-fest": "^1.2.2",
     "typescript": "^4.3.5"
+  },
+  "engines": {
+    "yarn": "please-use-npm"
   }
 }


### PR DESCRIPTION
## What does this change?

This PR adds some configuration so that running `yarn` commands will fail. This prevents accidental usage of `yarn` (instead of `npm`) and therefore erroneous, inconsistent behaviour as the repository is configured to use `npm`.

## How to test

Try running `yarn` and see that an error message is displayed. Try running `npm i` and see that it completes successfully.

## How can we measure success?

No unexpected behaviour due to `yarn` being used by accident. 
