### PR TITLE
chore: Bump dependencies (27/07)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,9 +1083,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -963,9 +963,9 @@
       }
     },
     "@octokit/webhooks-types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.1.0.tgz",
-      "integrity": "sha512-KQtzFYhhi3k3cGCeqo/PSEhmLZO/4DCtPSgeDG8M9De84fIvTvJbbt2ApeLgzNd6YNAbPjfbdxx8dRkc7jy5uA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.2.1.tgz",
+      "integrity": "sha512-2gazCdT3upEV/PQvT/Ya2lL/6dud6gg04zuHgpqkuduJfWllfFxS8/zctgNE8TvsOAAZxGhivvZ5gc370zKUzg==",
       "dev": true
     },
     "@sinonjs/commons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
-      "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
+      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -955,11 +955,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.21.1.tgz",
+      "integrity": "sha512-PP+m3T5EWZKawru4zi/FvX8KL2vkO5f1fLthx78/7743p7RtJUevt3z7698k+7oAYRA7YuVqfXthSEHqkDvZ8g==",
       "requires": {
-        "@octokit/openapi-types": "^8.3.0"
+        "@octokit/openapi-types": "^9.1.1"
       }
     },
     "@octokit/webhooks-types": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
     "@octokit/types": "^6.21.1",
-    "@octokit/webhooks-types": "^4.1.0",
+		"@octokit/webhooks-types": "^4.2.1",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.4.3",
     "@vercel/ncc": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/types": "^6.21.1",
     "@octokit/webhooks-types": "^4.1.0",
     "@types/jest": "^26.0.24",
-    "@types/node": "^16.3.3",
+    "@types/node": "^16.4.3",
     "@vercel/ncc": "^0.29.0",
     "eslint": "^7.31.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
-    "@octokit/types": "^6.19.0",
+    "@octokit/types": "^6.21.1",
     "@octokit/webhooks-types": "^4.1.0",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.3.3",


### PR DESCRIPTION
* bump @octokit/webhooks-types from 4.1.0 to 4.2.1
* bump @types/node from 16.3.3 to 16.4.3
* bump @octokit/types from 6.19.0 to 6.21.1