### PR TITLE
chore(deps): Bump dependencies (02/08)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
-      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.2.0.tgz",
+      "integrity": "sha512-c4A1Xm0At+ypvBfEETREu519wLncJYQXvY+dBGg/V5YA51eg5EwdDsPPfcOMG0cuXscqRvsIgIySTmTJUdcTNA=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -955,11 +955,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.21.1.tgz",
-      "integrity": "sha512-PP+m3T5EWZKawru4zi/FvX8KL2vkO5f1fLthx78/7743p7RtJUevt3z7698k+7oAYRA7YuVqfXthSEHqkDvZ8g==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.22.0.tgz",
+      "integrity": "sha512-Y8GR0BJHQDpO09qw/ZQpN+DXrFzCWaE0pvK4frDm3zJ+h99AktsFfBoDazbCtHxiL8d0jD8xRH4BeynlKLeChg==",
       "requires": {
-        "@octokit/openapi-types": "^9.1.1"
+        "@octokit/openapi-types": "^9.2.0"
       }
     },
     "@octokit/webhooks-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,9 +1083,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.4.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,9 +2285,9 @@
       }
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -2992,9 +2992,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -963,9 +963,9 @@
       }
     },
     "@octokit/webhooks-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.2.1.tgz",
-      "integrity": "sha512-2gazCdT3upEV/PQvT/Ya2lL/6dud6gg04zuHgpqkuduJfWllfFxS8/zctgNE8TvsOAAZxGhivvZ5gc370zKUzg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.2.2.tgz",
+      "integrity": "sha512-z51YJwwt0rfiBK9uAaebJz6Nps4uEwN9Cai0A10/CbUGiTdtpjK8xd7MxMojeWwCmJPCL9WmHbd3Os4xiGBAvg==",
       "dev": true
     },
     "@sinonjs/commons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6400,9 +6400,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.2.tgz",
-      "integrity": "sha512-pfkPYCcuV0TJoo/jlsUeWNV8rk7uMU6ocnYNvca1Vu+pyKi8Rl8Zo2scPt9O72gCsXIm+dMxOOWuA3VFDSdzWA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.3.0.tgz",
+      "integrity": "sha512-mYUYkAy6fPatVWtUeCV/qGeGL3IVucmdJOzeAEfwgCJDx8gP0JaW8jn6KQ5xDfPec31e0KXWn5EUOZMhquR1zA==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
-    "type-fest": "^1.2.2",
+    "type-fest": "^1.3.0",
     "typescript": "^4.3.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/types": "^6.21.1",
 		"@octokit/webhooks-types": "^4.2.2",
     "@types/jest": "^26.0.24",
-    "@types/node": "^16.4.3",
+    "@types/node": "^16.4.10",
     "@vercel/ncc": "^0.29.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
-    "@octokit/types": "^6.21.1",
-		"@octokit/webhooks-types": "^4.2.2",
+    "@octokit/types": "^6.22.0",
+    "@octokit/webhooks-types": "^4.2.2",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.4.10",
     "@vercel/ncc": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
     "@octokit/types": "^6.21.1",
-		"@octokit/webhooks-types": "^4.2.1",
+		"@octokit/webhooks-types": "^4.2.2",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.4.3",
     "@vercel/ncc": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.24",
     "@types/node": "^16.4.3",
     "@vercel/ncc": "^0.29.0",
-    "eslint": "^7.31.0",
+    "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "husky": "^7.0.1",
     "jest": "^26.6.3",


### PR DESCRIPTION
* bump @octokit/types from 6.21.1 to 6.22.0
* bump @types/node from 16.4.3 to 16.4.10
* bump type-fest from 1.2.2 to 1.3.0
* bump eslint from 7.31.0 to 7.32.0
* bump @octokit/webhooks-types from 4.2.1 to 4.2.2