### PR TITLE
chore(deps): Bump dependencies (06/09)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6508,9 +6508,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.0.0.tgz",
-      "integrity": "sha512-BoEUnckjP9oiudy3KxlGdudtBAdJQ74Wp7dYwVPkUzBn+cVHOsBXh2zD2jLyqgbuJ1KMNriczZCI7lTBA94dFg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.2.0.tgz",
+      "integrity": "sha512-T/HWTs/P20wqgy3GoIDv80tAB3Xvgk2vpxnS1vF8oVboipjrSB1hP5f1gFhCVt5QuMvOsALSwBBd02J94P51lg==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6523,9 +6523,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,9 +1149,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
-      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg==",
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,9 +3389,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.1.tgz",
-      "integrity": "sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
       "dev": true
     },
     "iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.7.0.tgz",
-      "integrity": "sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
+      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -955,11 +955,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.25.0.tgz",
-      "integrity": "sha512-bNvyQKfngvAd/08COlYIN54nRgxskmejgywodizQNyiKoXmWRAjKup2/LYwm+T9V0gsKH6tuld1gM0PzmOiB4Q==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
+      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
       "requires": {
-        "@octokit/openapi-types": "^9.5.0"
+        "@octokit/openapi-types": "^10.1.0"
       }
     },
     "@octokit/webhooks-types": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/types": "^6.27.0",
     "@octokit/webhooks-types": "^4.3.0",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.6",
+    "@types/node": "^16.7.10",
     "@vercel/ncc": "^0.30.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
     "type-fest": "^2.2.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.2"
   },
   "engines": {
     "yarn": "please-use-npm"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.6.1",
     "@guardian/prettier": "^0.6.0",
-    "@octokit/types": "^6.25.0",
+    "@octokit/types": "^6.27.0",
     "@octokit/webhooks-types": "^4.3.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
-    "type-fest": "^2.0.0",
+    "type-fest": "^2.2.0",
     "typescript": "^4.3.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vercel/ncc": "^0.30.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",
-    "husky": "^7.0.1",
+    "husky": "^7.0.2",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",


### PR DESCRIPTION
* bump @octokit/types from 6.25.0 to 6.27.0
* bump type-fest from 2.0.0 to 2.2.0
* bump husky from 7.0.1 to 7.0.2
* bump @types/node from 16.7.6 to 16.7.10
* bump typescript from 4.3.5 to 4.4.2