### PR TITLE
Use built in caching from setup-node action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,19 +11,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: 'npm'
+      - run: npm ci
       - run: ./script/build
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: 'npm'
+      - run: npm ci
       - run: ./script/lint
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: 'npm'
+      - run: npm ci
       - run: ./script/test

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ jobs:
               with:
                   persist-credentials: false
             - uses: guardian/actions-setup-node@main
-            - uses: bahmutov/npm-install@v1
+              with:
+                  cache: 'npm'
+            - run: npm ci
             - name: Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GU_GITHUB_TOKEN }}
@@ -99,7 +101,9 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - uses: guardian/actions-setup-node@main
-            - uses: bahmutov/npm-install@v1
+              with:
+                  cache: 'npm'
+            - run: npm ci
             - run: npm run test
     approve:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?

This change updates the _ci_ workflow to use caching implemented by [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) now that it's available. It also swaps out [bahmutov/npm-install](https://github.com/bahmutov/npm-install) for `npm ci` as we no longer need the caching implemented by that action.
