### PR TITLE
Target v2.4.1 of actions-setup-node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'npm'
       - run: npm ci
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'npm'
       - run: npm ci
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'npm'
       - run: npm ci


### PR DESCRIPTION
## What does this change?

Target a specific version of the [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) action